### PR TITLE
fix(docker): copy all backend source files to image to avoid missing …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,8 @@ WORKDIR /app
 # 复制前端构建产物
 COPY --from=frontend-builder /app/dist /app/frontend/dist
 
-# 复制后端文件
-COPY --from=backend-builder /app/package*.json /app/backend/
-COPY --from=backend-builder /app/node_modules /app/backend/node_modules
-COPY --from=backend-builder /app/server.js /app/backend/
-COPY --from=backend-builder /app/config /app/backend/config
+# 复制后端所有文件（包括 middlewares、routes、utils 等）
+COPY --from=backend-builder /app /app/backend
 
 # 设置工作目录为后端目录
 WORKDIR /app/backend


### PR DESCRIPTION
This pull request makes a change to the `Dockerfile` to simplify how backend files are copied during the build process. Instead of copying individual backend files and directories, the change now copies the entire backend directory.

Dockerfile changes:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R24): Replaced multiple `COPY` commands for backend files (`package*.json`, `node_modules`, `server.js`, `config`, etc.) with a single `COPY` command to copy the entire backend directory. This includes additional subdirectories like `middlewares`, `routes`, and `utils`.…modules