### PR TITLE
chore(ci): temporarily remove docker build cache to avoid GitHub Acti…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,6 @@ jobs:
         context: .
         push: true
         tags: ${{ secrets.DOCKER_HUB_USERNAME }}/photoommit:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         secrets: |
           "OSS_ACCESS_KEY_ID=${{ secrets.OSS_ACCESS_KEY_ID }}"
           "OSS_ACCESS_KEY_SECRET=${{ secrets.OSS_ACCESS_KEY_SECRET }}"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. It removes the Docker caching configuration (`cache-from` and `cache-to`) from the `jobs` section.…ons cache errors